### PR TITLE
ci: updates elixir/otp versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
           - elixir_version: '1.17'
             otp_version: '27.0'
             lint: true
-          - elixir_version: 1.15.7
+          - elixir_version: '1.16'
             otp_version: '26.2.5'
-          - elixir_version: 1.14.5
+          - elixir_version: '1.15'
             otp_version: '25.3.2.12'
-          - elixir_version: 1.13.4
+          - elixir_version: '1.14'
             otp_version: '25.3.2.12'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir_version: 1.16.1
-            otp_version: '26.2.1'
+          - elixir_version: 1.16.2
+            otp_version: '27.0'
             lint: true
           - elixir_version: 1.15.7
-            otp_version: '25.3.2.8'
+            otp_version: '26.2.5'
           - elixir_version: 1.14.5
-            otp_version: '24.3.4.15'
+            otp_version: '25.3.2.12'
           - elixir_version: 1.13.4
-            otp_version: '24.3.4.15'
+            otp_version: '25.3.2.12'
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
           - elixir_version: '1.15'
             otp_version: '25.3.2.12'
           - elixir_version: '1.14'
-            otp_version: '25.3.2.12'
+            otp_version: '24.3.4.17'
+          - elixir_version: '1.13'
+            otp_version: '24.3.4.17'
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir_version: 1.16.2
+          - elixir_version: '1.17'
             otp_version: '27.0'
             lint: true
           - elixir_version: 1.15.7


### PR DESCRIPTION
Blocker:
- `erlef/setup-beam` to support OPT 27.0